### PR TITLE
Fix schema files being placed in wrong folder after copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 EXT_DIR="$(HOME)/.local/share/gnome-shell/extensions"
 UUID=`perl -nle 'if (m{"uuid": "([^"]+)"}) { print $$1 }' metadata.json`
-FILES="AUTHORS COPYING README extension.js convenience.js prefs.js config.js metadata.json screenshot.png schemas/gschemas.compiled schemas/com.jonnylamb.shell-extensions.hide-legacy-tray.gschema.xml"
+FILES="AUTHORS COPYING README extension.js convenience.js prefs.js config.js metadata.json screenshot.png schemas"
 
 SCHEMA="org.gnome.shell"
 KEY="enabled-extensions"
@@ -41,12 +41,12 @@ install-link: uninstall-link compile-schemas
 
 uninstall-link:
 	@if [ -L $(EXT_DIR)/$(UUID) ]; then \
-	    rm $(EXT_DIR)/$(UUID); \
+	    rm -r $(EXT_DIR)/$(UUID); \
 	fi
 
 uninstall: disable-internal uninstall-link
 	@for f in "$(FILES)" ChangeLog; do \
-	    rm $(EXT_DIR)/$(UUID)/$$f 2> /dev/null || true; \
+	    rm -r $(EXT_DIR)/$(UUID)/$$f 2> /dev/null || true; \
 	done
 	@[ -d $(EXT_DIR)/$(UUID)/schemas ] && rmdir $(EXT_DIR)/$(UUID)/schemas; true
 	@[ -d $(EXT_DIR)/$(UUID) ] && rmdir $(EXT_DIR)/$(UUID); true


### PR DESCRIPTION
When the full path to the files in `schemas/` is given, it copies the files to the base folder so the file structure would look like this:
```
$ ls -la .local/share/gnome-shell/extensions/hide-legacy-tray@shell-extensions.jonnylamb.com
total 104
drwxr-xr-x 3 luna luna  4096 Dec  9 14:30 .
drwxr-xr-x 9 luna luna  4096 Dec  9 14:30 ..
-rw-r--r-- 1 luna luna    66 Dec  9 14:30 AUTHORS
-rw-r--r-- 1 luna luna   692 Dec  9 14:30 com.jonnylamb.shell-extensions.hide-legacy-tray.gschema.xml
-rw-r--r-- 1 luna luna   137 Dec  9 14:30 config.js
-rw-r--r-- 1 luna luna  1668 Dec  9 14:30 convenience.js
-rw-r--r-- 1 luna luna 26524 Dec  9 14:30 COPYING
-rw-r--r-- 1 luna luna  2925 Dec  9 14:30 extension.js
-rw-r--r-- 1 luna luna   396 Dec  9 14:30 gschemas.compiled
-rw-r--r-- 1 luna luna   349 Dec  9 14:30 metadata.json
-rw-r--r-- 1 luna luna  5270 Dec  9 14:30 prefs.js
-rw-r--r-- 1 luna luna   844 Dec  9 14:30 README
drwxr-xr-x 2 luna luna  4096 Dec  9 14:30 schemas
-rw-r--r-- 1 luna luna 21522 Dec  9 14:30 screenshot.png
```
As you can see, both `gschemas.compiled` and `com.jonnylamb.shell-extensions.hide-legacy-tray.gschema.xml` are placed outside the schemas folder.

After this change, only the `schemas` folder is put in the list of files that are copied, this will copy the whole schemas folder and everything in it to the new path instead of only the contents.

Fixes: https://github.com/jonnylamb/shell-hide-legacy-tray/issues/7